### PR TITLE
Fix: Add Windows compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Download a build of bun from a pull request in bun's github repository and add it to $PATH.
 
+### For Windows
+>You must run this script from the shell with `administrator` rights. Otherwise, you will get the error `"EPERM"` when creating a symlink.
+
+### How to use
+
 ```sh
 bunx bun-pr jarred/process-change
 ```

--- a/bun-pr.ts
+++ b/bun-pr.ts
@@ -150,7 +150,7 @@ type Pipeline = {
 async function* getBuildkitePipelineUrl(buildkiteUrl: string) {
   const headers = {
     Accept: "application/vnd.github.v3+json",
-    ...(GITHUB_TOKEN ? {Authorization: `token ${GITHUB_TOKEN}`} : {}),
+    ...(GITHUB_TOKEN ? { Authorization: `token ${GITHUB_TOKEN}` } : {}),
   };
 
   const statusesResponse = await fetch(buildkiteUrl + "?per_page=100", {
@@ -170,7 +170,7 @@ async function* getBuildkitePipelineUrl(buildkiteUrl: string) {
 }
 
 async function* getPRCommits(prNumber: number) {
-  const {data: commits} = await octokit.pulls.listCommits({
+  const { data: commits } = await octokit.pulls.listCommits({
     owner: REPO_OWNER,
     repo: REPO_NAME,
     pull_number: prNumber,
@@ -185,7 +185,7 @@ async function* getPRCommits(prNumber: number) {
 
   // Start with newest commits
   for (const commit of commits) {
-    const {data: statuses} = await octokit.repos.listCommitStatusesForRef({
+    const { data: statuses } = await octokit.repos.listCommitStatusesForRef({
       owner: REPO_OWNER,
       repo: REPO_NAME,
       ref: commit.sha,
@@ -406,7 +406,7 @@ function isArtifactName(name: string) {
 
 // Add this new function to fetch commit details
 async function getCommitDetails(sha: string) {
-  const {data: commitData} = await octokit.repos.getCommit({
+  const { data: commitData } = await octokit.repos.getCommit({
     owner: REPO_OWNER,
     repo: REPO_NAME,
     ref: sha,
@@ -421,25 +421,25 @@ const PR_OR_COMMIT = await (async () => {
   if (last?.startsWith("https://github.com")) {
     const parts = new URL(last).pathname.split("/");
     return parts[parts.length - 2] === "commit"
-      ? {type: "commit", value: parts.at(-1)}
-      : {type: "pr", value: parts.at(-1)};
+      ? { type: "commit", value: parts.at(-1) }
+      : { type: "pr", value: parts.at(-1) };
   } else if (last?.startsWith("https://api.github.com")) {
     const parts = new URL(last).pathname.split("/");
     return parts[parts.length - 2] === "commits"
-      ? {type: "commit", value: parts.at(-1)}
-      : {type: "pr", value: parts.at(-1)};
+      ? { type: "commit", value: parts.at(-1) }
+      : { type: "pr", value: parts.at(-1) };
   } else if (last?.startsWith("#")) {
-    return {type: "pr", value: last.slice(1)};
+    return { type: "pr", value: last.slice(1) };
   } else if (Number(last) === Number(last)) {
-    return {type: "pr", value: last};
+    return { type: "pr", value: last };
   }
   // long git sha or short git sha
   else if (last?.match(/^[0-9a-f]{40}$/) || last?.match(/^[0-9a-f]{7,}$/)) {
-    return {type: "commit", value: last};
+    return { type: "commit", value: last };
   } else {
     // resolve branch name to PR number or latest commit from argv
     const branch = last;
-    let {data: prs = []} = await octokit.pulls.list({
+    let { data: prs = [] } = await octokit.pulls.list({
       owner: REPO_OWNER,
       repo: REPO_NAME,
       state: "open",
@@ -447,9 +447,9 @@ const PR_OR_COMMIT = await (async () => {
     });
 
     if (prs.length) {
-      return {type: "pr", value: prs[0].number.toString()};
+      return { type: "pr", value: prs[0].number.toString() };
     } else {
-      const {data: commits} = await octokit.repos.listCommits({
+      const { data: commits } = await octokit.repos.listCommits({
         owner: REPO_OWNER,
         repo: REPO_NAME,
         sha: branch,
@@ -457,7 +457,7 @@ const PR_OR_COMMIT = await (async () => {
       });
 
       if (commits.length) {
-        return {type: "commit", value: commits[0].sha};
+        return { type: "commit", value: commits[0].sha };
       }
 
       throw new Error(`No open PR or recent commit found for branch ${branch}`);
@@ -582,10 +582,10 @@ for await (const artifact of await getBuildArtifactUrls(statusesUrl)) {
 
     await $`cp ${dest}/${inFolder} ${OUT_DIR}/${fullName} && rm -rf ${dest} ${OUT_DIR}/${inFolderWithoutExtension}-${PR_OR_COMMIT.value}${extension} ${OUT_DIR}/${inFolderWithoutExtension}-latest${extension}`.quiet();
     /**
-    * Need admin perms in shell (Windows)
-    * @see https://github.com/pnpm/pnpm/issues/4315
-    * @see https://github.com/nodejs/node-v0.x-archive/issues/9101
-    */
+     * Need admin perms in shell (Windows)
+     * @see https://github.com/pnpm/pnpm/issues/4315
+     * @see https://github.com/nodejs/node-v0.x-archive/issues/9101
+     */
     symlinkSync(
       `${OUT_DIR}${sep}${fullName}`,
       `${OUT_DIR}${sep}${inFolderWithoutExtension}-${PR_OR_COMMIT.value}${extension}`,

--- a/bun-pr.ts
+++ b/bun-pr.ts
@@ -14,7 +14,7 @@ $.cwd(cwd);
 process.chdir(cwd);
 
 let cachedResponses = new Map<string, Promise<Response>>();
-async function fetch(url: string, options: RequestInit) {
+async function fetch(url: string, options?: RequestInit) {
   if (cachedResponses.has(url)) {
     return (await cachedResponses.get(url))!.clone();
   }
@@ -476,7 +476,7 @@ console.log(
 const OUT_DIR =
   process.env.BUN_OUT_DIR ||
   (Bun.which("bun")
-    ? dirname(Bun.which("bun"))
+    ? dirname(Bun.which("bun") as string)
     : process.env.BUN_INSTALL || ".");
 
 // Modify the main download loop
@@ -503,7 +503,7 @@ if (PR_OR_COMMIT.type === "pr") {
   prData = response.data;
 } else {
   // Get commit details
-  const response = await getCommitDetails(PR_OR_COMMIT.value);
+  const response = await getCommitDetails(PR_OR_COMMIT.value!);
 
   if (!response?.url || !response?.sha) {
     throw new Error(`Failed to fetch commit data for ${PR_OR_COMMIT.value}`);
@@ -558,7 +558,7 @@ for await (const artifact of await getBuildArtifactUrls(statusesUrl)) {
   const dest = `bun-${PR_OR_COMMIT.value}-${sha}`;
 
   await $`rm -rf ${ARTIFACT_NAME} ${dest} ${ARTIFACT_NAME}.zip ${ARTIFACT_NAME}-artifact.zip ${filename}`;
-  await Bun.write(filename, blob);
+  await Bun.write(filename, blob as Blob);
   await $`unzip ${filename} && rm -rf ${filename}`.quiet();
   await $`cp -R ${ARTIFACT_NAME} ${dest}`;
   const files = readdirSync(`./${dest}`);


### PR DESCRIPTION
### Windows campability

If you use this script on windows (bun-pr), there were two problems:
- `unzip` command caused an error
- SymLink caused an error

In this PR, these errors have been fixed.

### Changes
- `unzip` command was changed to `tar -xf` in Windows
- Add guide how to use in Windows `(see P.S.)`

#### P.S. I've come up with three ways to work around this error:
- Use [`mklink`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/mklink) with hardlinks
- Turn on Developer Mode in Windows
- Run Shell as Admin

After a little time, I suggest that variant 3 is the most safe and comfortable. Because variant 2 isn't safe outside the console and variant 1 is a crutch that reduce size (x3).
